### PR TITLE
Security fix for gems rack, nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,17 +11,17 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
-    capybara-webkit (1.15.0)
+    capybara-webkit (1.15.1)
       capybara (>= 2.3, < 4.0)
       json
     coderay (1.1.2)
     dotenv (2.2.1)
-    json (2.1.0)
+    json (2.2.0)
     method_source (0.9.0)
     mini_mime (1.0.0)
-    mini_portile2 (2.3.0)
-    nokogiri (1.8.2)
-      mini_portile2 (~> 2.3.0)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.2)
+      mini_portile2 (~> 2.4.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -29,7 +29,7 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.0.2)
-    rack (2.0.4)
+    rack (2.0.6)
     rack-test (0.8.3)
       rack (>= 1.0, < 3)
     xpath (3.0.0)
@@ -45,4 +45,4 @@ DEPENDENCIES
   pry-byebug
 
 BUNDLED WITH
-   1.16.1
+   1.16.6


### PR DESCRIPTION
What:
https://github.com/simplybusiness/semaphore_stats/network/alerts
Security patch for gems:
Nokogiri CVE-2018-14404
Rack CVE-2018-16471 CVE-2018-16470

How:
$ bundle update nokogiri --conservative
$ bundle update rack --conservative

One dependency was also updated:
 Capybara-webkit(1.15.1)